### PR TITLE
Home de Administrador y crear encuesta

### DIFF
--- a/lib/Administrador/CrearEncuesta/crearEncuesta.dart
+++ b/lib/Administrador/CrearEncuesta/crearEncuesta.dart
@@ -1,0 +1,351 @@
+import 'package:flutter/material.dart';
+import 'package:urban_track/Administrador/CrearEncuesta/pregunta_abierta.dart';
+import 'package:urban_track/Administrador/CrearEncuesta/pregunta_escala.dart';
+import 'package:urban_track/Administrador/CrearEncuesta/pregunta_multiple.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class CrearEncuestaPage extends StatefulWidget {
+  const CrearEncuestaPage({super.key});
+
+  @override
+  State<CrearEncuestaPage> createState() => _CrearEncuestaPageState();
+  
+}
+
+class _CrearEncuestaPageState extends State<CrearEncuestaPage> {
+  bool _isSubmitting = false;
+  String? selectedProject;
+  final TextEditingController tituloController = TextEditingController();
+
+  List<Widget> preguntasWidgets = [];
+  List<TextEditingController> _preguntasControllers = [];
+
+  List<Map<String, dynamic>> proyectos = [];
+  bool loadingProyectos = true;
+
+  @override
+  void initState() {
+    super.initState();
+    fetchProyectos();
+  }
+
+  @override
+  void dispose() {
+    tituloController.dispose();
+    for (var c in _preguntasControllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> fetchProyectos() async {
+    try {
+      final response =
+          await http.get(Uri.parse('https://utbackend-xn26.onrender.com/proyectos'));
+      if (response.statusCode == 200) {
+        final List data = jsonDecode(response.body);
+        setState(() {
+          proyectos = data.map((e) => {'id': e['id'], 'nombre': e['nombre']}).toList();
+          loadingProyectos = false;
+        });
+      } else {
+        print('Error al cargar proyectos: ${response.statusCode}');
+        setState(() => loadingProyectos = false);
+      }
+    } catch (e) {
+      print('Error de conexión: $e');
+      setState(() => loadingProyectos = false);
+    }
+  }
+
+  void _agregarPregunta(String tipo) {
+    final controller = TextEditingController();
+    _preguntasControllers.add(controller);
+    final key = UniqueKey();
+
+    late Widget preguntaWidget;
+
+    if (tipo == "Abierta") {
+      preguntaWidget = PreguntaAbiertaWidget(
+        key: key,
+        controller: controller,
+        onDelete: () {
+          setState(() {
+            preguntasWidgets.removeWhere((w) => w.key == key);
+            _preguntasControllers.remove(controller);
+          });
+        },
+      );
+    } else if (tipo == "Opción Múltiple") {
+      preguntaWidget = PreguntaMultipleWidget(
+        key: key,
+        controller: controller,
+        onDelete: () {
+          setState(() {
+            preguntasWidgets.removeWhere((w) => w.key == key);
+            _preguntasControllers.remove(controller);
+          });
+        },
+      );
+    } else if (tipo == "Escala") {
+      preguntaWidget = PreguntaEscalaWidget(
+        key: key,
+        controller: controller,
+        onDelete: () {
+          setState(() {
+            preguntasWidgets.removeWhere((w) => w.key == key);
+            _preguntasControllers.remove(controller);
+          });
+        },
+      );
+    }
+
+    setState(() {
+      preguntasWidgets.add(preguntaWidget);
+    });
+  }
+
+  void _showAgregarPreguntaDialog() {
+    String? tipoSeleccionado;
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(builder: (context, setDialogState) {
+          return AlertDialog(
+            title: const Text("Selecciona tipo de pregunta"),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                RadioListTile<String>(
+                  title: const Text("Pregunta Abierta"),
+                  value: "Abierta",
+                  groupValue: tipoSeleccionado,
+                  onChanged: (value) {
+                    setDialogState(() {
+                      tipoSeleccionado = value;
+                    });
+                  },
+                ),
+                RadioListTile<String>(
+                  title: const Text("Opción Múltiple"),
+                  value: "Opción Múltiple",
+                  groupValue: tipoSeleccionado,
+                  onChanged: (value) {
+                    setDialogState(() {
+                      tipoSeleccionado = value;
+                    });
+                  },
+                ),
+                RadioListTile<String>(
+                  title: const Text("Escala"),
+                  value: "Escala",
+                  groupValue: tipoSeleccionado,
+                  onChanged: (value) {
+                    setDialogState(() {
+                      tipoSeleccionado = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+            actions: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text("Cancelar"),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      if (tipoSeleccionado != null) {
+                        _agregarPregunta(tipoSeleccionado!);
+                        Navigator.pop(context);
+                      }
+                    },
+                    child: const Text("Agregar"),
+                  ),
+                ],
+              ),
+            ],
+          );
+        });
+      },
+    );
+  }
+
+  Future<void> crearEncuesta() async {
+    if (_isSubmitting) return;
+    if (selectedProject == null || tituloController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Selecciona un proyecto y un título')),
+      );
+      return;
+    }
+
+       List<Map<String, dynamic>> preguntasData = preguntasWidgets.map((w) {
+                  if (w is PreguntaAbiertaWidget) {
+                    return w.toMap() as Map<String, dynamic>;
+                  } else if (w is PreguntaMultipleWidget) {
+                    return w.toMap() as Map<String, dynamic>;
+                  } else if (w is PreguntaEscalaWidget) {
+                    return w.toMap() as Map<String, dynamic>;
+                  }
+                  return <String, dynamic>{};
+                }).toList();
+
+    final body = {
+      "titulo": tituloController.text,
+      "proyectoId": int.parse(selectedProject!),
+      "administradorId":1,//ESTO SE HA DE CAMBIAR LUEGO DEL LOGIN PARA LOS ADMIN
+      "preguntas": preguntasData,
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse("https://utbackend-xn26.onrender.com/encuestas"),
+        headers: {"Content-Type": "application/json"},
+        body: jsonEncode(body),
+      );
+      
+      if (response.statusCode == 200) {
+        showCustomDialog(context, true); // éxito
+      } else {
+        showCustomDialog(context, false); // error
+      }
+    } catch (e) {
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text("Error"),
+          content: Text("Error de conexión: $e"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("Aceptar"),
+            )
+          ],
+        ),
+      );
+      print("Error de conexión: $e");
+    } finally {
+      setState(() => _isSubmitting = false); // habilitar botón de nuevo
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            "Crear Encuesta",
+            style: TextStyle(
+                fontSize: 24, fontWeight: FontWeight.bold, color: Color.fromARGB(255, 10, 128, 251)),
+          ),
+          const SizedBox(height: 16),
+          const Text("Seleccionar proyecto", style: TextStyle(fontSize: 20)),
+          DropdownButton<String>(
+            value: selectedProject,
+            hint: loadingProyectos
+                ? const Text("Cargando proyectos...")
+                : const Text("Selecciona un proyecto"),
+            items: proyectos
+                .map((p) => DropdownMenuItem(
+                      value: p['id'].toString(),
+                      child: Text(p['nombre']),
+                    ))
+                .toList(),
+            onChanged: (value) => setState(() => selectedProject = value),
+          ),
+          const SizedBox(height: 16),
+          const Text("Título", style: TextStyle(fontSize: 20)),
+          TextField(
+            controller: tituloController,
+            decoration: const InputDecoration(
+              hintText: "Ingresa el título de la encuesta",
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 10),
+          ElevatedButton.icon(
+            onPressed: _showAgregarPreguntaDialog,
+            label: const Text(
+              "Agregar pregunta",
+              style: TextStyle(color: Color.fromARGB(255, 10, 128, 251)),
+            ),
+            icon: const Icon(
+              Icons.add,
+              color: Color.fromARGB(255, 10, 128, 251),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: ListView.builder(
+              itemCount: preguntasWidgets.length,
+              itemBuilder: (context, index) => preguntasWidgets[index],
+            ),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: ElevatedButton(
+              onPressed: crearEncuesta,
+              style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 90, vertical: 16),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  backgroundColor: const Color.fromARGB(255, 95, 255, 18)),
+              child: const Text(
+                "Crear Encuesta",
+                style: TextStyle(fontSize: 18, color: Colors.black),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+
+void showCustomDialog(BuildContext context, bool success) {
+  showDialog(
+    context: context,
+    builder: (context) => Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              success ? Icons.check_circle : Icons.cancel,
+              color: success ? Colors.green : Colors.red,
+              size: 80,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              success ? "Encuesta creada correctamente" : "Error al crear encuesta",
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 24),
+            Align(
+              alignment: Alignment.center,
+              child: TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text(
+                  "Cerrar",
+                  style: TextStyle(fontSize: 16),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/Administrador/CrearEncuesta/pregunta_abierta.dart
+++ b/lib/Administrador/CrearEncuesta/pregunta_abierta.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class PreguntaAbiertaWidget extends StatelessWidget {
+  final TextEditingController controller;
+  final VoidCallback onDelete;
+
+  const PreguntaAbiertaWidget({
+    super.key,
+    required this.controller,
+    required this.onDelete,
+  });
+    Map<String, dynamic> toMap() {
+    return {
+      'tipo': 'abierta',
+      'pregunta': controller.text,
+      'opciones': [], // vacía porque es abierta
+    };
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: "Pregunta abierta",
+            border: InputBorder.none,
+          ),
+        ),
+        trailing: IconButton(
+          icon: const Icon(Icons.delete, color: Colors.red),
+          onPressed: onDelete,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Administrador/CrearEncuesta/pregunta_escala.dart
+++ b/lib/Administrador/CrearEncuesta/pregunta_escala.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class PreguntaEscalaWidget extends StatefulWidget {
+  final TextEditingController controller;
+  final VoidCallback onDelete;
+
+  final List<TextEditingController> opcionesControllers = [];
+
+  PreguntaEscalaWidget({
+    super.key,
+    required this.controller,
+    required this.onDelete,
+  });
+   Map<String, dynamic> toMap() {
+    return {
+      'tipo': 'escala',
+      'pregunta': controller.text,
+      'opciones': opcionesControllers.map((c) => c.text).toList(),
+    };
+  }
+  @override
+  State<PreguntaEscalaWidget> createState() => _PreguntaEscalaWidgetState();
+}
+
+class _PreguntaEscalaWidgetState extends State<PreguntaEscalaWidget> {
+
+  void _agregarOpcion() {
+    final controller = TextEditingController();
+    widget.opcionesControllers.add(controller);
+    setState(() {});
+  }
+
+  void _eliminarOpcion(int index) {
+    widget.opcionesControllers[index].dispose();
+    widget.opcionesControllers.removeAt(index);
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    for (var c in widget.opcionesControllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Pregunta + botón eliminar
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: widget.controller,
+                    decoration: const InputDecoration(
+                      hintText: "Ingresa la pregunta de escala",
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete, color: Colors.red),
+                  onPressed: widget.onDelete,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            // Lista de opciones
+            ...List.generate(widget.opcionesControllers.length, (index) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: widget.opcionesControllers[index],
+                        decoration: InputDecoration(
+                          hintText: "Opción ${index + 1}",
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete, color: Colors.red),
+                      onPressed: () => _eliminarOpcion(index),
+                    ),
+                  ],
+                ),
+              );
+            }),
+            const SizedBox(height: 8),
+            ElevatedButton.icon(
+              onPressed: _agregarOpcion,
+              icon: const Icon(Icons.add),
+              label: const Text("Agregar opción"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Administrador/CrearEncuesta/pregunta_multiple.dart
+++ b/lib/Administrador/CrearEncuesta/pregunta_multiple.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class PreguntaMultipleWidget extends StatefulWidget {
+  final TextEditingController controller;
+  final VoidCallback onDelete;
+  final List<TextEditingController> opcionesControllers = [];
+
+  PreguntaMultipleWidget({
+    super.key,
+    required this.controller,
+    required this.onDelete,
+  });
+    // Método para obtener los datos de esta pregunta
+  Map<String, dynamic> toMap() {
+    return {
+      'tipo': 'opcion_multiple',
+      'pregunta': controller.text,
+      'opciones': opcionesControllers.map((c) => c.text).toList(),
+    };
+  }
+  @override
+  State<PreguntaMultipleWidget> createState() => _PreguntaMultipleWidgetState();
+}
+
+class _PreguntaMultipleWidgetState extends State<PreguntaMultipleWidget> {
+  
+  void _agregarOpcion() {
+    final controller = TextEditingController();
+    widget.opcionesControllers.add(controller);
+    setState(() {});
+  }
+
+  void _eliminarOpcion(int index) {
+    widget.opcionesControllers[index].dispose();
+    widget.opcionesControllers.removeAt(index);
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    for (var c in widget.opcionesControllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Pregunta + botón eliminar
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: widget.controller,
+                    decoration: const InputDecoration(
+                      hintText: "Ingresa la pregunta",
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete, color: Colors.red),
+                  onPressed: widget.onDelete,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            // Lista de opciones
+            ...List.generate(widget.opcionesControllers.length, (index) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: widget.opcionesControllers[index],
+                        decoration: InputDecoration(
+                          hintText: "Opción ${index + 1}",
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete, color: Colors.red),
+                      onPressed: () => _eliminarOpcion(index),
+                    ),
+                  ],
+                ),
+              );
+            }),
+            const SizedBox(height: 8),
+            ElevatedButton.icon(
+              onPressed: _agregarOpcion,
+              icon: const Icon(Icons.add),
+              label: const Text("Agregar opción"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Administrador/homeAdmin.dart
+++ b/lib/Administrador/homeAdmin.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:urban_track/Administrador/CrearEncuesta/crearEncuesta.dart';
+// import 'package:urbantrack/Admin/encuestas_data.dart'; // ya no hace falta aquí
+// import 'package:urbantrack/Admin/card_encuesta.dart'; // tampoco
+
+class HomeAdmin extends StatefulWidget {
+  const HomeAdmin({super.key});
+
+  @override
+  State<HomeAdmin> createState() => _HomeAdminState();
+}
+
+class _HomeAdminState extends State<HomeAdmin> {
+  int _currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    // Ahora solo usamos el widget importado
+    Widget body;
+    if (_currentIndex == 0) {
+      body = const Center(child: Text("Encuestas publicadas", style: TextStyle(fontSize: 24))); // <--- aquí
+    } else if (_currentIndex == 1) {
+      body=const CrearEncuestaPage();
+    } else if (_currentIndex == 2) {
+      body = const Center(child: Text("⚙️ Configuración", style: TextStyle(fontSize: 24)));
+    } else {
+      body = const Center(child: Text("Otra pestaña", style: TextStyle(fontSize: 24)));
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        toolbarHeight: 0,
+      ),
+      body: body,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) => setState(() => _currentIndex = index),
+        backgroundColor: const Color.fromARGB(255, 10, 128, 251),
+        selectedItemColor: const Color.fromARGB(255, 10, 128, 251),
+        unselectedItemColor: Colors.grey,
+        elevation: 8,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.file_copy), label: "Encuestas"),
+          BottomNavigationBarItem(icon: Icon(Icons.file_download), label: "Crear"),
+          BottomNavigationBarItem(icon: Icon(Icons.add_circle), label: "Agregar"),
+          BottomNavigationBarItem(icon: Icon(Icons.logout), label: "Salir"),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:urban_track/Administrador/homeAdmin.dart';
 void main() {
   runApp(const MyApp());
 }
@@ -11,26 +11,9 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: 'Admin',
+      debugShowCheckedModeBanner: false,
+      home: HomeAdmin(),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -192,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -208,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.9.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Se agrego la pantalla de home de administrador como iniciador temporal, ahi estan las pestañas de ver encuestas publicadas, crear encuesta, agregar usuario (por ahora dice configuracion) y la pestaña de logout.
Se agrego el modulo de crear encuesta, con la api del servidor backend funcional, solo falta recuperar el id del administrador en sesion (cuando se haga login) para poder reemplazarlo en la ejecucion de la api, mientras tanto se usa el id 1 de administrador para crear encuestas.