### PR TITLE
Rama ver respuestas

### DIFF
--- a/lib/Administrador/homeAdmin.dart
+++ b/lib/Administrador/homeAdmin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:urban_track/Administrador/CrearEncuesta/crearEncuesta.dart';
 import 'package:urban_track/Administrador/agregarUsuario/agregar_usuario.dart';
+import 'package:urban_track/Administrador/resultadosEncuestas/ver_encuestas.dart';
 import 'package:urban_track/login.dart';
 import 'package:awesome_dialog/awesome_dialog.dart';
 
@@ -49,7 +50,7 @@ class _HomeAdminState extends State<HomeAdmin> {
 
     Widget body;
     if (_currentIndex == 0) {
-      body = const Center(child: Text("Encuestas publicadas", style: TextStyle(fontSize: 24)));
+      body = const VerEncuestas();
     } else if (_currentIndex == 1) {
       body = const CrearEncuestaPage();
     } else if (_currentIndex == 2) {

--- a/lib/Administrador/resultadosEncuestas/ver_encuestas.dart
+++ b/lib/Administrador/resultadosEncuestas/ver_encuestas.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class VerEncuestas extends StatefulWidget {
+  const VerEncuestas({super.key});
+
+  @override
+  State<VerEncuestas> createState() => _VerEncuestasState();
+}
+
+class _VerEncuestasState extends State<VerEncuestas> {
+  List<Map<String, dynamic>> encuestas = [];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    obtenerEncuestas();
+  }
+
+  Future<void> obtenerEncuestas() async {
+    setState(() {
+      isLoading = true;
+    });
+    try {
+      final response = await http.get(Uri.parse("http://localhost:3000/encuestas/all"));
+      if (response.statusCode == 200) {
+        final List<dynamic> data = jsonDecode(response.body);
+        setState(() {
+          encuestas = data.map((e) => {
+            'id': e['id'],
+            'proyecto': e['proyecto'],
+            'titulo': e['titulo']
+          }).toList();
+        });
+        print('Encuestas obtenidas con éxito');
+      } else {
+        print('Error al obtener las encuestas: ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Error de conexión: $e');
+    } finally {
+      setState(() {
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Encuestas Disponibles',
+          style: TextStyle(
+            color: Colors.blue,
+          ),
+        ),
+        centerTitle: false,
+      ),
+      body: isLoading
+          ? const Center(child: CircularProgressIndicator(color: Colors.blue))
+          : encuestas.isEmpty
+              ? const Center(child: Text('No hay encuestas disponibles'))
+              : ListView.builder(
+                  itemCount: encuestas.length,
+                  itemBuilder: (context, index) {
+                    final encuesta = encuestas[index];
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                      child: Card(
+                        elevation: 3,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.all(16.0),
+                          leading: const Icon(Icons.star_border, color: Colors.blue, size: 25),
+                          title: Text(
+                            encuesta['titulo'] ?? 'Sin Título',
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          subtitle: Text(
+                            encuesta['proyecto'] != null
+                            ? '${encuesta['proyecto']}'
+                            : 'Sin proyecto'
+                          ),
+                          trailing: ElevatedButton(
+                            onPressed: () {
+                              print('Ver respuestas para: ${encuesta['titulo']}');
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.lightGreen,
+                              foregroundColor: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                            ),
+                            child: const Text('Ver respuestas'),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                floatingActionButton: FloatingActionButton(
+                  onPressed: obtenerEncuestas,
+                  backgroundColor: Colors.green,
+                  child: Icon(Icons.refresh, color: Colors.white,),
+                ),
+    );
+  }
+}

--- a/lib/Administrador/resultadosEncuestas/ver_encuestas.dart
+++ b/lib/Administrador/resultadosEncuestas/ver_encuestas.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:urban_track/Administrador/resultadosEncuestas/ver_resultados.dart';
 
 class VerEncuestas extends StatefulWidget {
   const VerEncuestas({super.key});
@@ -88,6 +89,7 @@ class _VerEncuestasState extends State<VerEncuestas> {
                           ),
                           trailing: ElevatedButton(
                             onPressed: () {
+                              Navigator.push(context, MaterialPageRoute(builder: (context) => VerResultados(encuestaId: encuesta['id'], encuestaTitulo: encuesta['titulo'],)));
                               print('Ver respuestas para: ${encuesta['titulo']}');
                             },
                             style: ElevatedButton.styleFrom(

--- a/lib/Administrador/resultadosEncuestas/ver_resultados.dart
+++ b/lib/Administrador/resultadosEncuestas/ver_resultados.dart
@@ -1,0 +1,322 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:fl_chart/fl_chart.dart';
+
+class PreguntaData {
+  final int id;
+  final String titulo;
+  final String tipo;
+  final int totalRespuestas;
+  final List<OpcionData> opciones;
+
+  PreguntaData({
+    required this.id,
+    required this.titulo,
+    required this.tipo,
+    required this.totalRespuestas,
+    required this.opciones,
+  });
+
+  factory PreguntaData.fromJson(Map<String, dynamic> json) {
+    return PreguntaData(
+      id: json['idpregunta'],
+      titulo: json['pregunta'],
+      tipo: json['tipo'],
+      totalRespuestas: json['total_respuestas'],
+      opciones: (json['opciones'] as List)
+          .map((op) => OpcionData.fromJson(op))
+          .toList(),
+    );
+  }
+}
+
+class OpcionData {
+  final String opcion;
+  final int conteo;
+  final double porcentaje;
+
+  OpcionData({
+    required this.opcion,
+    required this.conteo,
+    required this.porcentaje,
+  });
+
+  factory OpcionData.fromJson(Map<String, dynamic> json) {
+    return OpcionData(
+      opcion: json['opcion'],
+      conteo: json['conteo'],
+      porcentaje: json['porcentaje'] is int
+          ? (json['porcentaje'] as int).toDouble()
+          : json['porcentaje'],
+    );
+  }
+}
+
+class VerResultados extends StatefulWidget {
+  final int encuestaId;
+  final String encuestaTitulo;
+
+  const VerResultados({
+    super.key,
+    required this.encuestaId,
+    required this.encuestaTitulo,
+  });
+
+  @override
+  State<VerResultados> createState() => _VerResultadosState();
+}
+
+class _VerResultadosState extends State<VerResultados> {
+  int totalRespuestas = 0;
+  List<PreguntaData> preguntas = [];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    fetchResultados();
+  }
+
+  Future<void> fetchResultados() async {
+    setState(() {
+      isLoading = true;
+    });
+    try {
+      final response = await http.get(Uri.parse('http://localhost:3000/encuestas/${widget.encuestaId}/resultados'));
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> data = jsonDecode(response.body);
+        setState(() {
+          totalRespuestas = data['totalRespuestas'];
+          preguntas = (data['preguntas'] as List)
+              .map((p) => PreguntaData.fromJson(p))
+              .toList();
+        });
+        print('Resultados obtenidos con éxito');
+      } else {
+        print('Error al cargar resultados: ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Error de conexión o datos: $e');
+    } finally {
+      setState(() {
+        isLoading = false;
+      });
+    }
+  }
+
+  Widget buildPieChart(PreguntaData pregunta) {
+    return AspectRatio(
+      aspectRatio: 1.3,
+      child: Card(
+        color: Colors.black,
+        child: Column(
+          children: <Widget>[
+            const SizedBox(height: 10),
+            Expanded(
+              child: PieChart(
+                PieChartData(
+                  sections: pregunta.opciones.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final opcion = entry.value;
+                    return PieChartSectionData(
+                      color: Colors.primaries[index % Colors.primaries.length],
+                      value: opcion.porcentaje,
+                      title: '${opcion.opcion}\n${opcion.porcentaje.toStringAsFixed(1)}%',
+                      radius: 50,
+                      titleStyle: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                    );
+                  }).toList(),
+                  sectionsSpace: 2,
+                  centerSpaceRadius: 40,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget buildBarChart(PreguntaData pregunta) {
+    return AspectRatio(
+      aspectRatio: 1.3,
+      child: Card(
+        color: Colors.white,
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              const SizedBox(height: 10),
+              Expanded(
+                child: BarChart(
+                  BarChartData(
+                    alignment: BarChartAlignment.spaceAround,
+                    maxY: 100,
+                    barGroups: pregunta.opciones.asMap().entries.map((entry) {
+                      final index = entry.key;
+                      final opcion = entry.value;
+                      return BarChartGroupData(
+                        x: index,
+                        barRods: [
+                          BarChartRodData(
+                            toY: opcion.porcentaje,
+                            color: Colors.primaries[index % Colors.primaries.length],
+                            width: 15,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                        ],
+                      );
+                    }).toList(),
+                    titlesData: FlTitlesData(
+                      show: true,
+                      bottomTitles: AxisTitles(
+                        sideTitles: SideTitles(
+                          showTitles: true,
+                          getTitlesWidget: (value, TitleMeta meta) {
+                            final opcion = pregunta.opciones[value.toInt()];
+                            return SideTitleWidget(
+                              meta: meta,
+                              space: 4,
+                              child: Text(opcion.opcion, style: const TextStyle(fontSize: 10)),
+                            );
+                          },
+                        ),
+                      ),
+                      leftTitles: const AxisTitles(
+                        sideTitles: SideTitles(showTitles: true, interval: 20, reservedSize: 44),
+                      ),
+                      topTitles: const AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                      rightTitles: const AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                    ),
+                    borderData: FlBorderData(
+                      show: false,
+                    ),
+                    gridData: FlGridData(
+                      show: true,
+                      drawVerticalLine: false,
+                      getDrawingHorizontalLine: (value) {
+                        return const FlLine(
+                          color: Color(0xffececec),
+                          strokeWidth: 1,
+                        );
+                      },
+                    ),
+                    barTouchData: BarTouchData(
+                      touchTooltipData: BarTouchTooltipData(
+                        getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                          final opcion = pregunta.opciones[groupIndex];
+                          return BarTooltipItem(
+                            '${opcion.opcion}\n${opcion.porcentaje.toStringAsFixed(1)}%',
+                            const TextStyle(color: Colors.white),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () => Navigator.pop(context),
+          icon: const Icon(Icons.arrow_back),
+          style: IconButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+          ),
+        ),
+        title: Text(widget.encuestaTitulo),
+      ),
+      body: isLoading
+          ? const Center(child: CircularProgressIndicator(color: Colors.blue))
+          : SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Card(
+                    elevation: 4,
+                    child: Padding(
+                      padding: const EdgeInsets.all(20.0),
+                      child: Column(
+                        children: [
+                          const Text(
+                            'Total de Respuestas',
+                            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                          ),
+                          const SizedBox(height: 10),
+                          Text(
+                            totalRespuestas.toString(),
+                            style: const TextStyle(fontSize: 48, fontWeight: FontWeight.bold, color: Colors.blue),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+
+                  if (preguntas.isEmpty)
+                    const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(20.0),
+                        child: Text(
+                          'No hay respuestas de opción múltiple para mostrar.',
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    )
+                  else
+                  ...preguntas.map((pregunta) {
+                    if (pregunta.opciones.isEmpty || pregunta.totalRespuestas == 0) {
+                      return const SizedBox.shrink();
+                    }
+                    return Column(
+                      children: [
+                        Text(
+                          pregunta.titulo,
+                          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 10),
+                        SizedBox(
+                          height: 300,
+                          width: 500, 
+                          child: buildPieChart(pregunta),
+                        ),
+                        const SizedBox(height: 20),
+                        SizedBox(
+                          height: 300,
+                          width: 500,
+                          child: buildBarChart(pregunta),
+                        ),
+                        const Divider(height: 40),
+                      ],
+                    );
+                  }),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,99 +7,12 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Admin',
       debugShowCheckedModeBanner: false,
       home: const LoginPage(),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -73,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "7ca9a40f4eb85949190e54087be8b4d6ac09dc4c54238d782a34cf1f7c011de9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -295,4 +311,4 @@ packages:
     version: "1.1.1"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   http: ^1.1.0
   awesome_dialog: ^3.0.6 # PARA USAR awesome_dialog, DIALOGOS BONITOS PARA LA APP
+  fl_chart: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Funciones implementadas:

1. Mostrar todas las encuestas para ver sus resultados
2. Mostrar el total de respuestas
3. Mostrar las preguntas abiertas y sus respuestas
4. Mostrar gráfico de pastel de preguntas de opción múltiple
5. Mostrar gráfico de barras de preguntas de opción múltiple

@DiegoLaguna-17 Habría que cambiar el URI de las funciones de 'localhost' al URI del remoto en `render:
Ejemplo:
`await http.get(Uri.parse("http://localhost:3000/encuestas/all"));`
`await http.get(Uri.parse("https://utbackend-xn26.onrender.com/encuestas/all"));`